### PR TITLE
modified naming convention of alto.py

### DIFF
--- a/1.0-Set-up-the-software.md
+++ b/1.0-Set-up-the-software.md
@@ -154,8 +154,8 @@ $ git clone https://TODO Alto
 
 7. Run the app
 ```
-$ cd ~/code/Alto/app
-$ python3 Alto.py
+$ cd ~/code/alto/app
+$ python3 alto.py
 ```
 
 ## :tada: Woohoo! You've finished this section :tada:


### PR DESCRIPTION
Hello - I changed the naming convention of the main py file so that the name of the py file in line 157 of 1.0-Set-up-the-software.md matches filename in repo googlecreativelab/alto/app/alto.py. 